### PR TITLE
Bump httpclient from 4.5.9 to 4.5.13 in /Batch-Compliance/java

### DIFF
--- a/Batch-Compliance/java/pom.xml
+++ b/Batch-Compliance/java/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.9</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Bumps httpclient from 4.5.9 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>